### PR TITLE
fix: update default node version from 16 to 20

### DIFF
--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -20,7 +20,7 @@ parameters:
     default: "main"
   node-version:
     type: string
-    default: "16.5.0"
+    default: "20.11.1"
     description: "Specify the NodeJS version used to run the commitlint job. This should not usually need to be changed."
   max-count:
     type: integer


### PR DESCRIPTION
The current version of commitlint no longer works on node 16, which is what this orb is set to use by default. Since node 16 is EOL anyway we needed to upgrade.

Using latest LTS release as of current time.

Fixes #11 